### PR TITLE
Add condition for postgres >=10 due to packaging change

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -38,7 +38,7 @@
     - postgresql_config
 
 - name: Initialize the DB with system.d
-  shell: /usr/pgsql-{{ postgresql_yumrepo_version }}/bin/postgresql{{ postgresql_yumrepo_ver }}-setup initdb
+  shell: /usr/pgsql-{{ postgresql_yumrepo_version }}/bin/postgresql{{'-' if postgresql_yumrepo_ver | int >= 10 else '' }}{{ postgresql_yumrepo_ver }}-setup initdb
   environment:
     PGDATA: "{{ postgresql_data_directory }}"
   when: >


### PR DESCRIPTION
It seems the packaging has changed for postgres >= 10, and the setup script now has an extra hyphen.
See the below:
```
[root@70d4f2dde65d /]# rpm -qa | egrep 'postgres.*server'
postgresql11-server-11.6-2PGDG.rhel7.x86_64
postgresql10-server-10.11-2PGDG.rhel7.x86_64
postgresql12-server-12.1-2PGDG.rhel7.x86_64
postgresql96-server-9.6.16-2PGDG.rhel7.x86_64
[root@70d4f2dde65d /]# ll /usr/pgsql-*/bin/*-setup
-rwxr-xr-x 1 root root 9419 Nov 30 14:29 /usr/pgsql-10/bin/postgresql-10-setup
-rwxr-xr-x 1 root root 9418 Nov 30 14:11 /usr/pgsql-11/bin/postgresql-11-setup
-rwxr-xr-x 1 root root 9418 Nov 30 13:31 /usr/pgsql-12/bin/postgresql-12-setup
-rwxr-xr-x 1 root root 9427 Nov 30 15:00 /usr/pgsql-9.6/bin/postgresql96-setup
```
This extra condition will add the hyphen if the postgres version is greater than or equal to 10.